### PR TITLE
Add bracketleft/bracketright wider glyphs

### DIFF
--- a/glyphs/u005B-wider/README.md
+++ b/glyphs/u005B-wider/README.md
@@ -1,0 +1,6 @@
+<img height="60" alt="left-regular" src="https://user-images.githubusercontent.com/206409/34211653-1238cd6a-e59a-11e7-977e-bb9e2d292ee0.png">
+<img height="60" alt="left-bold" src="https://user-images.githubusercontent.com/206409/34211661-183cf358-e59a-11e7-8e80-035c10906403.png">
+<img height="60" alt="left-italic" src="https://user-images.githubusercontent.com/206409/34211670-1e144b6e-e59a-11e7-9c99-f523059e5c19.png">
+<img height="60" alt="left-bolditalic" src="https://user-images.githubusercontent.com/206409/34211673-21220c56-e59a-11e7-9f87-5e4fca1a6fac.png">
+
+Check out [BRUTALISM Hack](https://github.com/BRUTALISM/Hack) to see the glyphs in action.

--- a/glyphs/u005B-wider/bold/bracketleft.glif
+++ b/glyphs/u005B-wider/bold/bracketleft.glif
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="bracketleft" format="1">
+  <advance width="1233"/>
+  <unicode hex="005B"/>
+  <outline>
+    <contour>
+      <point x="284" y="1636" type="line" name="dh01"/>
+      <point x="987" y="1636" type="line" name="sh01"/>
+      <point x="987" y="1446" type="line" name="dv02"/>
+      <point x="549" y="1446" type="line" name="hr01"/>
+      <point x="549" y="-85" type="line"/>
+      <point x="987" y="-85" type="line" name="hr02"/>
+      <point x="987" y="-270" type="line" name="dv01"/>
+      <point x="284" y="-270" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2017-07-11 17:15:08 +0000</string>
+    </dict>
+  </lib>
+</glyph>

--- a/glyphs/u005B-wider/bolditalic/bracketleft.glif
+++ b/glyphs/u005B-wider/bolditalic/bracketleft.glif
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="bracketleft" format="1">
+  <advance width="1233"/>
+  <unicode hex="005B"/>
+  <outline>
+    <contour>
+      <point x="549" y="1651" type="line" name="hr00"/>
+      <point x="1204" y="1651" type="line" name="dv04"/>
+      <point x="1176" y="1478" type="line" name="dv03"/>
+      <point x="756" y="1478" type="line"/>
+      <point x="505" y="-112" type="line"/>
+      <point x="925" y="-112" type="line" name="dv02"/>
+      <point x="897" y="-285" type="line" name="dv01"/>
+      <point x="242" y="-285" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2017-07-11 17:15:08 +0000</string>
+    </dict>
+  </lib>
+</glyph>

--- a/glyphs/u005B-wider/italic/bracketleft.glif
+++ b/glyphs/u005B-wider/italic/bracketleft.glif
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="bracketleft" format="1">
+  <advance width="1233"/>
+  <unicode hex="005B"/>
+  <outline>
+    <contour>
+      <point x="582" y="1636" type="line" name="hr00"/>
+      <point x="1206" y="1636" type="line" name="dv04"/>
+      <point x="1183" y="1493" type="line" name="dv03"/>
+      <point x="743" y="1493" type="line"/>
+      <point x="487" y="-127" type="line"/>
+      <point x="927" y="-127" type="line" name="dv02"/>
+      <point x="904" y="-270" type="line" name="dv01"/>
+      <point x="280" y="-270" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2017-07-11 17:15:08 +0000</string>
+    </dict>
+  </lib>
+</glyph>

--- a/glyphs/u005B-wider/regular/bracketleft.glif
+++ b/glyphs/u005B-wider/regular/bracketleft.glif
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="bracketleft" format="1">
+  <advance width="1233"/>
+  <unicode hex="005B"/>
+  <outline>
+    <contour>
+      <point x="323" y="1636" type="line" name="dh01"/>
+      <point x="947" y="1636" type="line" name="sh01"/>
+      <point x="947" y="1493" type="line" name="dv02"/>
+      <point x="507" y="1493" type="line" name="hr01"/>
+      <point x="507" y="-127" type="line"/>
+      <point x="947" y="-127" type="line" name="hr02"/>
+      <point x="947" y="-270" type="line" name="dv01"/>
+      <point x="323" y="-270" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2017-07-11 17:15:08 +0000</string>
+    </dict>
+  </lib>
+</glyph>

--- a/glyphs/u005D-wider/README.md
+++ b/glyphs/u005D-wider/README.md
@@ -1,0 +1,6 @@
+<img height="60" alt="right-regular" src="https://user-images.githubusercontent.com/206409/34211786-73ec6bc0-e59a-11e7-9f17-0c1b1f4df253.png">
+<img height="60" alt="right-bold" src="https://user-images.githubusercontent.com/206409/34211790-768e434e-e59a-11e7-937d-5250bb706280.png">
+<img height="60" alt="right-italic" src="https://user-images.githubusercontent.com/206409/34211794-7942e16c-e59a-11e7-8d43-293115127b63.png">
+<img height="60" alt="right-bolditalic" src="https://user-images.githubusercontent.com/206409/34211796-7b517b9e-e59a-11e7-99bb-12587de5d47d.png">
+
+Check out [BRUTALISM Hack](https://github.com/BRUTALISM/Hack) to see the glyphs in action.

--- a/glyphs/u005D-wider/bold/bracketright.glif
+++ b/glyphs/u005D-wider/bold/bracketright.glif
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="bracketright" format="1">
+  <advance width="1233"/>
+  <unicode hex="005D"/>
+  <outline>
+    <contour>
+      <point x="244" y="-83" type="line" name="hr00"/>
+      <point x="687" y="-83" type="line" name="sh01"/>
+      <point x="687" y="1445" type="line"/>
+      <point x="244" y="1445" type="line" name="sh02"/>
+      <point x="244" y="1635" type="line" name="dv01"/>
+      <point x="949" y="1635" type="line" name="hr01"/>
+      <point x="949" y="-270" type="line" name="dh01"/>
+      <point x="244" y="-270" type="line" name="hr02"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2017-07-11 17:15:08 +0000</string>
+    </dict>
+  </lib>
+</glyph>

--- a/glyphs/u005D-wider/bolditalic/bracketright.glif
+++ b/glyphs/u005D-wider/bolditalic/bracketright.glif
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="bracketright" format="1">
+  <advance width="1233"/>
+  <unicode hex="005D"/>
+  <outline>
+    <contour>
+      <point x="273" y="-112" type="line" name="hr00"/>
+      <point x="693" y="-112" type="line" name="dv02"/>
+      <point x="944" y="1477" type="line"/>
+      <point x="524" y="1477" type="line" name="dv03"/>
+      <point x="552" y="1650" type="line" name="dv04"/>
+      <point x="1207" y="1650" type="line"/>
+      <point x="900" y="-285" type="line" name="dv01"/>
+      <point x="245" y="-285" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2017-07-11 17:15:08 +0000</string>
+    </dict>
+  </lib>
+</glyph>

--- a/glyphs/u005D-wider/italic/bracketright.glif
+++ b/glyphs/u005D-wider/italic/bracketright.glif
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="bracketright" format="1">
+  <advance width="1233"/>
+  <unicode hex="005D"/>
+  <outline>
+    <contour>
+      <point x="266" y="-127" type="line" name="hr00"/>
+      <point x="706" y="-127" type="line" name="dv02"/>
+      <point x="962" y="1492" type="line" name="dv03"/>
+      <point x="522" y="1492" type="line"/>
+      <point x="545" y="1635" type="line"/>
+      <point x="1169" y="1635" type="line" name="dv04"/>
+      <point x="867" y="-270" type="line" name="dv01"/>
+      <point x="243" y="-270" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2017-07-11 17:15:08 +0000</string>
+    </dict>
+  </lib>
+</glyph>

--- a/glyphs/u005D-wider/regular/bracketright.glif
+++ b/glyphs/u005D-wider/regular/bracketright.glif
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="bracketright" format="1">
+  <advance width="1233"/>
+  <unicode hex="005D"/>
+  <outline>
+    <contour>
+      <point x="286" y="-127" type="line" name="hr00"/>
+      <point x="726" y="-127" type="line" name="sh01"/>
+      <point x="726" y="1492" type="line" name="dv01"/>
+      <point x="286" y="1492" type="line" name="sh02"/>
+      <point x="286" y="1635" type="line"/>
+      <point x="910" y="1635" type="line" name="hr01"/>
+      <point x="910" y="-270" type="line" name="dh01"/>
+      <point x="286" y="-270" type="line" name="hr02"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2017-07-11 17:15:08 +0000</string>
+    </dict>
+  </lib>
+</glyph>


### PR DESCRIPTION
Adding wider versions of `bracketleft` and `bracketright`. Try before you buy: https://github.com/BRUTALISM/Hack 😉 

@chrissimpkins Can you tell me how you made those screenshots in each glyph's README, so I can update the PR to match? I see they're not hosted inside the repo, did you use GitHub's new file dialog to add the README and magically upload the images to githubusercontent?