### PR TITLE
Add alternate curved parentheses with smoother curves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/glyphs/u0028-curved/README.md
+++ b/glyphs/u0028-curved/README.md
@@ -1,0 +1,7 @@
+<img height=60 src="https://user-images.githubusercontent.com/206409/44809284-95d24c00-abce-11e8-9c86-14e5bc0766da.png">
+
+<img height=60 src="https://user-images.githubusercontent.com/206409/44809355-c0240980-abce-11e8-8856-2bd36a3bc50a.png">
+
+<img height=60 src="https://user-images.githubusercontent.com/206409/44809363-c5815400-abce-11e8-93f8-4c61a2a0d794.png">
+
+<img height=60 src="https://user-images.githubusercontent.com/206409/44809372-cca86200-abce-11e8-9d38-d51c5208f1da.png">

--- a/glyphs/u0028-curved/bold/parenleft.glif
+++ b/glyphs/u0028-curved/bold/parenleft.glif
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="parenleft" format="1">
+  <advance width="1233"/>
+  <unicode hex="0028"/>
+  <outline>
+    <contour>
+      <point x="977" y="-205" type="line" name="hr00"/>
+      <point x="567" y="-86"/>
+      <point x="244" y="255"/>
+      <point x="244" y="747" type="curve" smooth="yes" name="dh01"/>
+      <point x="244" y="1238"/>
+      <point x="576" y="1591.25"/>
+      <point x="977" y="1700" type="curve" name="at01"/>
+      <point x="977" y="1485" type="line"/>
+      <point x="671" y="1359"/>
+      <point x="509" y="1104"/>
+      <point x="509" y="747" type="curve" smooth="yes" name="dh02"/>
+      <point x="509" y="389"/>
+      <point x="672" y="136"/>
+      <point x="977" y="10" type="curve" name="av01"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2018-06-05 00:49:11 +0000</string>
+    </dict>
+  </lib>
+</glyph>

--- a/glyphs/u0028-curved/bolditalic/parenleft.glif
+++ b/glyphs/u0028-curved/bolditalic/parenleft.glif
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="parenleft" format="1">
+  <advance width="1233"/>
+  <unicode hex="0028"/>
+  <outline>
+    <contour>
+      <point x="822" y="-236" type="line" name="hr00"/>
+      <point x="493" y="-168"/>
+      <point x="286" y="154"/>
+      <point x="286" y="594" type="curve" smooth="yes"/>
+      <point x="286" y="651"/>
+      <point x="290" y="696"/>
+      <point x="298" y="752" type="curve" smooth="yes" name="dh01"/>
+      <point x="371" y="1265"/>
+      <point x="690" y="1624"/>
+      <point x="1131" y="1700" type="curve" name="at01"/>
+      <point x="1101" y="1527" type="line"/>
+      <point x="807" y="1439"/>
+      <point x="628" y="1181"/>
+      <point x="561" y="736" type="curve" smooth="yes" name="dh02"/>
+      <point x="548" y="650"/>
+      <point x="541" y="574"/>
+      <point x="541" y="503" type="curve" smooth="yes"/>
+      <point x="541" y="208"/>
+      <point x="652" y="3"/>
+      <point x="850" y="-63" type="curve" name="av01"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2018-06-05 00:50:28 +0000</string>
+    </dict>
+  </lib>
+</glyph>

--- a/glyphs/u0028-curved/italic/parenleft.glif
+++ b/glyphs/u0028-curved/italic/parenleft.glif
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="parenleft" format="1">
+  <advance width="1233"/>
+  <unicode hex="0028"/>
+  <outline>
+    <contour>
+      <point x="798" y="-206" type="line" name="hr00"/>
+      <point x="474" y="-105"/>
+      <point x="284" y="155"/>
+      <point x="284" y="578" type="curve" smooth="yes"/>
+      <point x="284" y="1133"/>
+      <point x="630" y="1560"/>
+      <point x="1100" y="1700" type="curve" name="at01"/>
+      <point x="1077" y="1557" type="line"/>
+      <point x="666" y="1373"/>
+      <point x="456" y="1048"/>
+      <point x="456" y="593" type="curve" smooth="yes"/>
+      <point x="456" y="251"/>
+      <point x="574" y="39"/>
+      <point x="821" y="-63" type="curve" name="av01"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2018-06-05 00:44:29 +0000</string>
+    </dict>
+  </lib>
+</glyph>

--- a/glyphs/u0028-curved/regular/parenleft.glif
+++ b/glyphs/u0028-curved/regular/parenleft.glif
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="parenleft" format="1">
+  <advance width="1233"/>
+  <unicode hex="0028"/>
+  <outline>
+    <contour>
+      <point x="947" y="-206" type="line" name="hr00"/>
+      <point x="552" y="-51"/>
+      <point x="293" y="250.821"/>
+      <point x="293" y="747" type="curve" smooth="yes" name="dh01"/>
+      <point x="293" y="1243.18"/>
+      <point x="555" y="1548"/>
+      <point x="947" y="1700" type="curve" name="at01"/>
+      <point x="947" y="1532" type="line"/>
+      <point x="631.582" y="1379.21"/>
+      <point x="477" y="1121.02"/>
+      <point x="477" y="747" type="curve" smooth="yes" name="dh02"/>
+      <point x="477" y="372.98"/>
+      <point x="631.582" y="114.795"/>
+      <point x="947" y="-38" type="curve" name="av01"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2017-07-11 17:15:08 +0000</string>
+    </dict>
+  </lib>
+</glyph>

--- a/glyphs/u0029-curved/README.md
+++ b/glyphs/u0029-curved/README.md
@@ -1,0 +1,7 @@
+<img height=60 src="https://user-images.githubusercontent.com/206409/44809468-1133fd80-abcf-11e8-89eb-2538c1f04ae7.png">
+
+<img height=60 src="https://user-images.githubusercontent.com/206409/44809478-185b0b80-abcf-11e8-9766-55235343286e.png">
+
+<img height=60 src="https://user-images.githubusercontent.com/206409/44809487-1ee98300-abcf-11e8-9590-6588031464f7.png">
+
+<img height=60 src="https://user-images.githubusercontent.com/206409/44809502-2872eb00-abcf-11e8-8a85-8d5eebf4f23e.png">

--- a/glyphs/u0029-curved/bold/parenright.glif
+++ b/glyphs/u0029-curved/bold/parenright.glif
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="parenright" format="1">
+  <advance width="1233"/>
+  <unicode hex="0029"/>
+  <outline>
+    <contour>
+      <point x="254" y="-205" type="line" name="hr00"/>
+      <point x="664" y="-86"/>
+      <point x="987" y="255"/>
+      <point x="987" y="747" type="curve" smooth="yes" name="dh01"/>
+      <point x="987" y="1238"/>
+      <point x="655" y="1591.25"/>
+      <point x="254" y="1700" type="curve" name="at01"/>
+      <point x="254" y="1485" type="line"/>
+      <point x="560" y="1359"/>
+      <point x="722" y="1104"/>
+      <point x="722" y="747" type="curve" smooth="yes" name="dh02"/>
+      <point x="722" y="389"/>
+      <point x="559" y="136"/>
+      <point x="254" y="10" type="curve" name="av01"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2018-06-05 00:49:05 +0000</string>
+    </dict>
+  </lib>
+</glyph>

--- a/glyphs/u0029-curved/bolditalic/parenright.glif
+++ b/glyphs/u0029-curved/bolditalic/parenright.glif
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="parenright" format="1">
+  <advance width="1233"/>
+  <unicode hex="0029"/>
+  <outline>
+    <contour>
+      <point x="478" y="1700" type="line" name="hr00"/>
+      <point x="792" y="1608"/>
+      <point x="1010" y="1311"/>
+      <point x="1010" y="873" type="curve" smooth="yes"/>
+      <point x="1010" y="815"/>
+      <point x="1007" y="768"/>
+      <point x="998" y="708" type="curve" smooth="yes" name="dh01"/>
+      <point x="920" y="189"/>
+      <point x="623" y="-149"/>
+      <point x="171" y="-235" type="curve" name="at01"/>
+      <point x="199" y="-62" type="line"/>
+      <point x="511" y="20"/>
+      <point x="755" y="465"/>
+      <point x="755" y="930" type="curve" smooth="yes"/>
+      <point x="755" y="1236"/>
+      <point x="650" y="1436"/>
+      <point x="451" y="1527" type="curve" name="av01"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2018-06-05 00:50:46 +0000</string>
+    </dict>
+  </lib>
+</glyph>

--- a/glyphs/u0029-curved/italic/parenright.glif
+++ b/glyphs/u0029-curved/italic/parenright.glif
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="parenright" format="1">
+  <advance width="1233"/>
+  <unicode hex="0029"/>
+  <outline>
+    <contour>
+      <point x="508" y="1700" type="line" name="hr00"/>
+      <point x="840" y="1575"/>
+      <point x="1019" y="1335"/>
+      <point x="1019" y="914" type="curve" smooth="yes"/>
+      <point x="1019" y="362"/>
+      <point x="717" y="-48"/>
+      <point x="200" y="-205" type="curve" name="at01"/>
+      <point x="223" y="-62" type="line"/>
+      <point x="594" y="102"/>
+      <point x="765" y="328"/>
+      <point x="829" y="746" type="curve" smooth="yes" name="dh02"/>
+      <point x="841" y="825"/>
+      <point x="847" y="894"/>
+      <point x="847" y="958" type="curve" smooth="yes"/>
+      <point x="847" y="1252"/>
+      <point x="722" y="1459"/>
+      <point x="485" y="1557" type="curve" name="av01"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2018-06-05 00:44:49 +0000</string>
+    </dict>
+  </lib>
+</glyph>

--- a/glyphs/u0029-curved/regular/parenright.glif
+++ b/glyphs/u0029-curved/regular/parenright.glif
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="parenright" format="1">
+  <advance width="1233"/>
+  <unicode hex="0029"/>
+  <outline>
+    <contour>
+      <point x="286" y="-206" type="line" name="hr00"/>
+      <point x="681" y="-51"/>
+      <point x="940" y="250.821"/>
+      <point x="940" y="747" type="curve" smooth="yes" name="dh01"/>
+      <point x="940" y="1243.18"/>
+      <point x="678" y="1548"/>
+      <point x="286" y="1700" type="curve" name="at01"/>
+      <point x="286" y="1532" type="line"/>
+      <point x="601.418" y="1379.21"/>
+      <point x="756" y="1121.02"/>
+      <point x="756" y="747" type="curve" smooth="yes" name="dh02"/>
+      <point x="756" y="372.98"/>
+      <point x="601.418" y="114.795"/>
+      <point x="286" y="-38" type="curve" name="av01"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2018-06-04 23:57:45 +0000</string>
+    </dict>
+  </lib>
+</glyph>


### PR DESCRIPTION
The soon-to-be-official `u0028-rounder` and `u0029-rounder` alternates are almost perfect, but their curves are messy. This is obvious at larger sizes, but also when viewed on a high DPI (i.e. Retina) screen if you have a sharp eye.

Here's my take on it:

![alternate](https://user-images.githubusercontent.com/206409/44810609-7ccb9a00-abd2-11e8-9b02-cbfe689d2033.png)

And here it is overlaid on top of `u0028-rounder` and `u0029-rounder`:

![comparison](https://user-images.githubusercontent.com/206409/44810673-aedcfc00-abd2-11e8-8da0-f47671adc16c.png)

You can see the orange parts sticking out, which are to my eye superfluous. Here's a side-by-side comparison (my mod is blue, the soon-to-be-official is orange):

![comparison2](https://user-images.githubusercontent.com/206409/44811040-d5e7fd80-abd3-11e8-84fe-3ed1fa304288.png)

Is it just me, or are these annotated regions (in red) appearing thicker than they should be?

![annotated](https://user-images.githubusercontent.com/206409/44811157-2cedd280-abd4-11e8-8168-a774f2f4393a.png)

Anyway, didn't want to complain about it in the Hack repo, so I rolled up my sleeves and fixed it. 😉 